### PR TITLE
feat: optimize search performance with thread-local caching

### DIFF
--- a/src/main/java/project/SearchCoords.java
+++ b/src/main/java/project/SearchCoords.java
@@ -44,6 +44,14 @@ public class SearchCoords {
     private int currentThreadCount;
     private boolean currentCheckGeneration;
 
+    // ================= 线程缓存优化 =================
+    private static final ThreadLocal<NoiseCache> NOISE_CACHE =
+            new ThreadLocal<>();
+    private static final ThreadLocal<CheeseNoiseCache> CHEESE_CACHE =
+            new ThreadLocal<>();
+    private static final ThreadLocal<SeedChecker> SEED_CHECKER =
+            new ThreadLocal<>();
+
     public static class ProgressInfo {
         public final long processed;
         public final long total;
@@ -257,6 +265,11 @@ public class SearchCoords {
 
         @Override
         public void run() {
+            NOISE_CACHE.set(new NoiseCache(seed));
+            CHEESE_CACHE.set(new CheeseNoiseCache(seed));
+            SEED_CHECKER.set(
+                    new SeedChecker(seed, TargetState.NO_STRUCTURES, SeedCheckerDimension.OVERWORLD)
+            );
             // 将maxHeight转换为int，用于Box和check方法
             int maxHeightInt = (int) maxHeight;
             int expectedAirCount = 128 - (int)maxHeight;
@@ -393,7 +406,11 @@ public class SearchCoords {
     }
 
     public boolean check(long seed, int x, int z, int maxHeight) {
-        NoiseCache cache = new NoiseCache(seed);
+        NoiseCache cache = NOISE_CACHE.get();
+        if (cache == null) {
+            cache = new NoiseCache(seed);
+            NOISE_CACHE.set(cache);
+        }
         double erosionSample = cache.erosion.sample((double) x / 4, 0, (double) z / 4);
         if (erosionSample < 0.55) {
             return false;
@@ -497,7 +514,11 @@ public class SearchCoords {
     }
 
     public static double Entrance(long worldseed, int x, int y, int z) {
-        NoiseCache cache = new NoiseCache(worldseed);
+        NoiseCache cache = NOISE_CACHE.get();
+        if (cache == null) {
+            cache = new NoiseCache(worldseed);
+            NOISE_CACHE.set(cache);
+        }
         double c = cache.caveEntrance.sample(x * 0.75, y * 0.5, z * 0.75) + 0.37 +
                 MathHelper.clampedLerp(0.3, 0.0, (10 + (double) y) / 40.0);
         double d = cache.spaghettiRarity.sample(x * 2, y, z * 2);
@@ -514,14 +535,24 @@ public class SearchCoords {
     }
 
     public static double Cheese(long worldseed, int x, int y, int z) {
-        CheeseNoiseCache cache = new CheeseNoiseCache(worldseed);
+        CheeseNoiseCache cache = CHEESE_CACHE.get();
+        if (cache == null) {
+            cache = new CheeseNoiseCache(worldseed);
+            CHEESE_CACHE.set(cache);
+        }
+
         double a = 4 * cache.caveLayer.sample(x, y * 8, z) * cache.caveLayer.sample(x, y * 8, z);
         double b = MathHelper.clamp((0.27 + cache.caveCheese.sample(x, y * 0.6666666666666666, z)), -1, 1);
         return a + b;//Actually there still need to add a function about sloped_cheese, but sloped_cheese is too complex and IDK how to calculate it.
     }
 
     public static double Entrance2(long worldseed, int x, int y, int z) {
-        NoiseCache cache = new NoiseCache(worldseed);
+        NoiseCache cache = NOISE_CACHE.get();
+        if (cache == null) {
+            cache = new NoiseCache(worldseed);
+            NOISE_CACHE.set(cache);
+        }
+
         double d = cache.spaghettiRarity.sample(x * 2, y, z * 2);
         double e = NoiseColumnSampler.CaveScaler.scaleTunnels(d);
         double h = Util.lerpFromProgress(cache.spaghettiThickness, x, y, z, 0.065, 0.088);


### PR DESCRIPTION
### What
This PR introduces a thread-local caching mechanism for noise-related computations
to reduce redundant object creation during large-scale coordinate searches.

Specifically:
- Add `ThreadLocal<NoiseCache>`, `ThreadLocal<CheeseNoiseCache>` and `ThreadLocal<SeedChecker>`
- Initialize caches once per worker thread instead of per check
- Reuse cached noise samplers in `check`, `Entrance`, `Cheese`, and related methods

---

### 内容说明
本次提交引入了基于 `ThreadLocal` 的缓存机制，用于优化与噪声相关的计算过程，
以减少在大规模坐标搜索过程中频繁创建对象所带来的性能开销。

具体包括：
- 新增 `ThreadLocal<NoiseCache>`、`ThreadLocal<CheeseNoiseCache>` 和 `ThreadLocal<SeedChecker>`
- 每个工作线程仅初始化一次缓存，而非每次检查都重新创建
- 在 `check`、`Entrance`、`Cheese` 等方法中复用缓存的噪声采样器

---

### Why
Previously, `NoiseCache`, `CheeseNoiseCache`, and `SeedChecker` instances were created
repeatedly for each coordinate check, which caused significant overhead during
multi-threaded searches.

By reusing thread-local instances:
- Object allocation pressure is greatly reduced
- CPU cache locality is improved
- Overall search throughput is significantly increased

This optimization is especially noticeable when scanning large regions with
multiple worker threads.

---

### 优化动机
在原实现中，每次坐标检测都会重复创建 `NoiseCache`、`CheeseNoiseCache`
以及 `SeedChecker` 实例，在多线程、大规模搜索场景下会带来明显的性能开销。

通过引入线程本地缓存：
- 显著减少对象创建与 GC 压力
- 提高 CPU 缓存命中率
- 大幅提升整体搜索吞吐性能

该优化在多线程扫描大区域时尤为明显。

---

### How
- Use `ThreadLocal` to bind cache instances to each search thread
- Lazily initialize caches on first access
- Ensure thread safety without introducing synchronization overhead
- Preserve existing algorithm behavior and output correctness

---

### 实现方式
- 使用 `ThreadLocal` 将缓存实例绑定到各自的搜索线程
- 在首次访问时进行懒加载初始化
- 避免引入额外的同步机制，保证线程安全
- 不修改原有算法逻辑与计算结果，仅优化执行效率

---

### Impact
- No changes to public APIs
- No changes to search results
- Performance improvement only (algorithm remains identical)

---

### 影响范围
- 不涉及任何公共 API 变更
- 搜索结果保持完全一致
- 仅进行性能层面的优化，算法行为不变

---

### Test
- Verified that search results remain consistent before and after the change
- On my local machine, the estimated runtime for the same search workload
  was reduced from over **4 hours** to approximately **40 minutes**
  under multi-threaded execution

> Note: Actual performance gains may vary depending on hardware,
> JVM settings, and search parameters.

---

### 测试情况
- 对比修改前后的搜索结果，结果保持一致
- 在本人本地环境中，对相同搜索任务进行测试：
  预计运行时间由原先的 **4 小时以上**
  降低至约 **40 分钟**（多线程执行）

> 注：具体性能提升幅度可能会因硬件配置、
> JVM 参数及搜索参数不同而有所差异
