### PR TITLE
feat: support Large Biomes preset and use generated hut floor Y when available

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,8 @@ dependencies {
 
 
     implementation('com.seedfinding:latticg:1.06@jar')
-    implementation 'org.junit.jupiter:junit-jupiter:5.8.1'
-    implementation 'org.junit.jupiter:junit-jupiter:5.8.1'
-    implementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.8.1'
 
 }
 test {
@@ -45,6 +44,7 @@ test {
 shadowJar {
     archiveBaseName.set('LowYSwampHut')
     archiveClassifier.set('')
+    archiveVersion.set('')
     mergeServiceFiles()
 }
 
@@ -54,6 +54,7 @@ task buildMainJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJ
     description = 'Creates a fat JAR for LowYSwampHutForFixedSeed'
     archiveBaseName.set('LowYSwampHutForFixedSeedGUI')
     archiveClassifier.set('')
+    archiveVersion.set('')
     from sourceSets.main.output
     configurations = [project.configurations.runtimeClasspath]
     manifest {

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ test {
 shadowJar {
     archiveBaseName.set('LowYSwampHut')
     archiveClassifier.set('')
-    archiveVersion.set('')
     mergeServiceFiles()
 }
 
@@ -54,7 +53,6 @@ task buildMainJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJ
     description = 'Creates a fat JAR for LowYSwampHutForFixedSeed'
     archiveBaseName.set('LowYSwampHutForFixedSeedGUI')
     archiveClassifier.set('')
-    archiveVersion.set('')
     from sourceSets.main.output
     configurations = [project.configurations.runtimeClasspath]
     manifest {

--- a/src/main/java/nl/jellejurre/seedchecker/serverMocks/FakeSaveProperties.java
+++ b/src/main/java/nl/jellejurre/seedchecker/serverMocks/FakeSaveProperties.java
@@ -1,0 +1,166 @@
+package nl.jellejurre.seedchecker.serverMocks;
+
+import com.mojang.serialization.Lifecycle;
+import net.minecraft.client.world.GeneratorType;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.resource.DataPackSettings;
+import net.minecraft.util.registry.DynamicRegistryManager;
+import net.minecraft.world.Difficulty;
+import net.minecraft.world.GameMode;
+import net.minecraft.world.GameRules;
+import net.minecraft.world.SaveProperties;
+import net.minecraft.world.gen.GeneratorOptions;
+import net.minecraft.world.level.LevelInfo;
+import net.minecraft.world.level.ServerWorldProperties;
+import org.jetbrains.annotations.Nullable;
+import project.WorldPresetMode;
+
+import java.util.Set;
+
+public class FakeSaveProperties implements SaveProperties {
+    private static final ThreadLocal<WorldPresetMode> WORLD_PRESET_MODE =
+            ThreadLocal.withInitial(() -> WorldPresetMode.NORMAL);
+
+    private final FakeServerWorldProperties fakeServerWorldProperties = new FakeServerWorldProperties();
+    private final GeneratorOptions generatorOptions;
+
+    public FakeSaveProperties(DynamicRegistryManager.Impl registryManager, long seed) {
+        GeneratorType generatorType = WORLD_PRESET_MODE.get() == WorldPresetMode.LARGE_BIOMES
+                ? GeneratorType.LARGE_BIOMES
+                : GeneratorType.DEFAULT;
+        generatorOptions = generatorType.createDefaultOptions(registryManager, seed, true, false);
+    }
+
+    public static void setWorldPresetMode(WorldPresetMode worldPresetMode) {
+        WORLD_PRESET_MODE.set(worldPresetMode == null ? WorldPresetMode.NORMAL : worldPresetMode);
+    }
+
+    public static void clearWorldPresetMode() {
+        WORLD_PRESET_MODE.remove();
+    }
+
+    @Override
+    public DataPackSettings getDataPackSettings() {
+        return null;
+    }
+
+    @Override
+    public void updateLevelInfo(DataPackSettings dataPackSettings) {
+    }
+
+    @Override
+    public boolean isModded() {
+        return false;
+    }
+
+    @Override
+    public Set<String> getServerBrands() {
+        return null;
+    }
+
+    @Override
+    public void addServerBrand(String brand, boolean modded) {
+    }
+
+    @Nullable
+    @Override
+    public NbtCompound getCustomBossEvents() {
+        return null;
+    }
+
+    @Override
+    public void setCustomBossEvents(@Nullable NbtCompound nbt) {
+    }
+
+    @Override
+    public ServerWorldProperties getMainWorldProperties() {
+        return this.fakeServerWorldProperties;
+    }
+
+    @Override
+    public LevelInfo getLevelInfo() {
+        return null;
+    }
+
+    @Override
+    public NbtCompound cloneWorldNbt(DynamicRegistryManager registryManager,
+                                     @Nullable NbtCompound playerNbt) {
+        return null;
+    }
+
+    @Override
+    public boolean isHardcore() {
+        return false;
+    }
+
+    @Override
+    public int getVersion() {
+        return 0;
+    }
+
+    @Override
+    public String getLevelName() {
+        return null;
+    }
+
+    @Override
+    public GameMode getGameMode() {
+        return null;
+    }
+
+    @Override
+    public void setGameMode(GameMode gameMode) {
+    }
+
+    @Override
+    public boolean areCommandsAllowed() {
+        return false;
+    }
+
+    @Override
+    public Difficulty getDifficulty() {
+        return null;
+    }
+
+    @Override
+    public void setDifficulty(Difficulty difficulty) {
+    }
+
+    @Override
+    public boolean isDifficultyLocked() {
+        return false;
+    }
+
+    @Override
+    public void setDifficultyLocked(boolean locked) {
+    }
+
+    @Override
+    public GameRules getGameRules() {
+        return null;
+    }
+
+    @Override
+    public NbtCompound getPlayerData() {
+        return null;
+    }
+
+    @Override
+    public NbtCompound getDragonFight() {
+        return null;
+    }
+
+    @Override
+    public void setDragonFight(NbtCompound nbt) {
+    }
+
+    @Override
+    public GeneratorOptions getGeneratorOptions() {
+        return this.generatorOptions;
+    }
+
+    @Override
+    public Lifecycle getLifecycle() {
+        return null;
+    }
+}

--- a/src/main/java/project/LowYSwampHutForFixedSeed.java
+++ b/src/main/java/project/LowYSwampHutForFixedSeed.java
@@ -34,6 +34,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
     private JLabel searchThreadCountLabel;
     private JLabel searchHeightLabel;
     private JLabel searchVersionLabel;
+    private JLabel searchWorldPresetLabel;
     private JLabel searchMinXLabel;
     private JLabel searchMaxXLabel;
     private JLabel searchMinZLabel;
@@ -44,6 +45,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
     private JTextField searchThreadCountField;
     private JComboBox<String> maxHeightComboBox;
     private JComboBox<String> versionComboBox;
+    private JComboBox<String> worldPresetComboBox;
     private JTextField minXField;
     private JTextField maxXField;
     private JTextField minZField;
@@ -82,6 +84,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
     private JLabel listSearchThreadCountLabel;
     private JLabel listSearchHeightLabel;
     private JLabel listSearchVersionLabel;
+    private JLabel listSearchWorldPresetLabel;
     private JLabel listSearchMinXLabel;
     private JLabel listSearchMaxXLabel;
     private JLabel listSearchMinZLabel;
@@ -91,6 +94,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
     private JTextField listSearchThreadCountField;
     private JComboBox<String> listMaxHeightComboBox;
     private JComboBox<String> listVersionComboBox;
+    private JComboBox<String> listWorldPresetComboBox;
     private JTextField listMinXField;
     private JTextField listMaxXField;
     private JTextField listMinZField;
@@ -275,9 +279,24 @@ public class LowYSwampHutForFixedSeed extends JFrame {
         versionComboBox.setSelectedIndex(0); // 默认选择 1.21.1
         inputPanel.add(versionComboBox, gbc);
 
-        // MinX 输入
+        // 世界类型选择下拉框
         gbc.gridx = 0;
         gbc.gridy = 4;
+        gbc.fill = GridBagConstraints.NONE;
+        gbc.weightx = 0;
+        searchWorldPresetLabel = new JLabel(getString("label.worldPreset"));
+        searchWorldPresetLabel.setFont(getLoadedFont());
+        inputPanel.add(searchWorldPresetLabel, gbc);
+        gbc.gridx = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.weightx = 1.0;
+        worldPresetComboBox = new JComboBox<>(getWorldPresetOptions());
+        worldPresetComboBox.setSelectedIndex(0);
+        inputPanel.add(worldPresetComboBox, gbc);
+
+        // MinX 输入
+        gbc.gridx = 0;
+        gbc.gridy = 5;
         gbc.fill = GridBagConstraints.NONE;
         gbc.weightx = 0;
         JLabel minXLabel = new JLabel("MinX(x512):");
@@ -297,7 +316,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
 
         // MaxX 输入
         gbc.gridx = 0;
-        gbc.gridy = 5;
+        gbc.gridy = 6;
         gbc.fill = GridBagConstraints.NONE;
         gbc.weightx = 0;
         JLabel maxXLabel = new JLabel("MaxX(x512):");
@@ -316,7 +335,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
 
         // MinZ 输入
         gbc.gridx = 0;
-        gbc.gridy = 6;
+        gbc.gridy = 7;
         gbc.fill = GridBagConstraints.NONE;
         gbc.weightx = 0;
         JLabel minZLabel = new JLabel("MinZ(x512):");
@@ -335,7 +354,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
 
         // MaxZ 输入
         gbc.gridx = 0;
-        gbc.gridy = 7;
+        gbc.gridy = 8;
         gbc.fill = GridBagConstraints.NONE;
         gbc.weightx = 0;
         JLabel maxZLabel = new JLabel("MaxZ(x512):");
@@ -354,7 +373,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
 
         // 精确检查生成情况复选框
         gbc.gridx = 0;
-        gbc.gridy = 8;
+        gbc.gridy = 9;
         gbc.fill = GridBagConstraints.NONE;
         gbc.weightx = 0;
         searchCheckGenerationLabel = new JLabel(getString("label.checkGeneration"));
@@ -370,7 +389,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
 
         // 语言选择下拉框
         gbc.gridx = 0;
-        gbc.gridy = 9;
+        gbc.gridy = 10;
         gbc.fill = GridBagConstraints.NONE;
         gbc.weightx = 0;
         searchLanguageLabel = new JLabel(getString("label.language"));
@@ -607,6 +626,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
                 searchThreadCountField.setEnabled(true);
                 maxHeightComboBox.setEnabled(true);
                 versionComboBox.setEnabled(true);
+                worldPresetComboBox.setEnabled(true);
                 minXField.setEnabled(true);
                 maxXField.setEnabled(true);
                 minZField.setEnabled(true);
@@ -751,10 +771,11 @@ public class LowYSwampHutForFixedSeed extends JFrame {
                     double maxHeight = Double.parseDouble(selectedHeight);
                     String selectedVersion = (String) versionComboBox.getSelectedItem();
                     MCVersion mcVersion = getMCVersion(selectedVersion != null ? selectedVersion : "1.21.1");
+                    WorldPresetMode worldPresetMode = getWorldPresetMode((String) worldPresetComboBox.getSelectedItem());
 
                     // 如果版本变化，需要重新创建searcher
-                    if (searcher == null || !searcher.getMCVersion().equals(mcVersion)) {
-                        searcher = new SearchCoords(mcVersion);
+                    if (searcher == null || !searcher.getMCVersion().equals(mcVersion) || searcher.getWorldPresetMode() != worldPresetMode) {
+                        searcher = new SearchCoords(mcVersion, worldPresetMode);
                     }
 
                     // 调用startSearch，它会检测到暂停状态并调整线程数
@@ -973,6 +994,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
             searchThreadCountField.setEnabled(false); // 运行中不能修改，暂停时可以修改
             maxHeightComboBox.setEnabled(false);
             versionComboBox.setEnabled(false);
+            worldPresetComboBox.setEnabled(false);
             minXField.setEnabled(false);
             maxXField.setEnabled(false);
             minZField.setEnabled(false);
@@ -990,8 +1012,9 @@ public class LowYSwampHutForFixedSeed extends JFrame {
             // 获取选择的版本
             String selectedVersion = (String) versionComboBox.getSelectedItem();
             MCVersion mcVersion = getMCVersion(selectedVersion != null ? selectedVersion : "1.21.1");
+            WorldPresetMode worldPresetMode = getWorldPresetMode((String) worldPresetComboBox.getSelectedItem());
 
-            searcher = new SearchCoords(mcVersion);
+            searcher = new SearchCoords(mcVersion, worldPresetMode);
             boolean checkGeneration = searchCheckGenerationCheckBox.isSelected();
             searcher.startSearch(seed, threadCount, minX, maxX, minZ, maxZ, maxHeight, this::updateSearchProgress, this::addSearchResult, checkGeneration);
 
@@ -1035,6 +1058,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
         searchThreadCountField.setEnabled(true);
         maxHeightComboBox.setEnabled(true);
         versionComboBox.setEnabled(true);
+        worldPresetComboBox.setEnabled(true);
         minXField.setEnabled(true);
         maxXField.setEnabled(true);
         minZField.setEnabled(true);
@@ -1136,9 +1160,24 @@ public class LowYSwampHutForFixedSeed extends JFrame {
         listVersionComboBox.setSelectedIndex(0); // 默认选择 1.21.1
         inputPanel.add(listVersionComboBox, gbc);
 
-        // MinX 输入
+        // 世界类型选择下拉框
         gbc.gridx = 0;
         gbc.gridy = 4;
+        gbc.fill = GridBagConstraints.NONE;
+        gbc.weightx = 0;
+        listSearchWorldPresetLabel = new JLabel(getString("label.worldPreset"));
+        listSearchWorldPresetLabel.setFont(getLoadedFont());
+        inputPanel.add(listSearchWorldPresetLabel, gbc);
+        gbc.gridx = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.weightx = 1.0;
+        listWorldPresetComboBox = new JComboBox<>(getWorldPresetOptions());
+        listWorldPresetComboBox.setSelectedIndex(0);
+        inputPanel.add(listWorldPresetComboBox, gbc);
+
+        // MinX 输入
+        gbc.gridx = 0;
+        gbc.gridy = 5;
         gbc.fill = GridBagConstraints.NONE;
         gbc.weightx = 0;
         listSearchMinXLabel = new JLabel(getString("label.minX"));
@@ -1157,7 +1196,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
 
         // MaxX 输入
         gbc.gridx = 0;
-        gbc.gridy = 5;
+        gbc.gridy = 6;
         gbc.fill = GridBagConstraints.NONE;
         gbc.weightx = 0;
         listSearchMaxXLabel = new JLabel(getString("label.maxX"));
@@ -1176,7 +1215,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
 
         // MinZ 输入
         gbc.gridx = 0;
-        gbc.gridy = 6;
+        gbc.gridy = 7;
         gbc.fill = GridBagConstraints.NONE;
         gbc.weightx = 0;
         listSearchMinZLabel = new JLabel(getString("label.minZ"));
@@ -1195,7 +1234,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
 
         // MaxZ 输入
         gbc.gridx = 0;
-        gbc.gridy = 7;
+        gbc.gridy = 8;
         gbc.fill = GridBagConstraints.NONE;
         gbc.weightx = 0;
         listSearchMaxZLabel = new JLabel(getString("label.maxZ"));
@@ -1214,7 +1253,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
 
         // 精确检查生成情况复选框
         gbc.gridx = 0;
-        gbc.gridy = 8;
+        gbc.gridy = 9;
         gbc.fill = GridBagConstraints.NONE;
         gbc.weightx = 0;
         listSearchCheckGenerationLabel = new JLabel(getString("label.checkGeneration"));
@@ -1370,6 +1409,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
                 searchThreadCountField.setEnabled(true);
                 maxHeightComboBox.setEnabled(true);
                 versionComboBox.setEnabled(true);
+                worldPresetComboBox.setEnabled(true);
                 minXField.setEnabled(true);
                 maxXField.setEnabled(true);
                 minZField.setEnabled(true);
@@ -1524,6 +1564,17 @@ public class LowYSwampHutForFixedSeed extends JFrame {
         };
     }
 
+    private String[] getWorldPresetOptions() {
+        return new String[]{getString("worldPreset.normal"), getString("worldPreset.largeBiomes")};
+    }
+
+    private WorldPresetMode getWorldPresetMode(String presetLabel) {
+        if (presetLabel != null && presetLabel.equals(getString("worldPreset.largeBiomes"))) {
+            return WorldPresetMode.LARGE_BIOMES;
+        }
+        return WorldPresetMode.NORMAL;
+    }
+
     /**
      * 切换语言
      */
@@ -1618,6 +1669,9 @@ public class LowYSwampHutForFixedSeed extends JFrame {
         if (searchVersionLabel != null) {
             searchVersionLabel.setText(getString("label.version"));
         }
+        if (searchWorldPresetLabel != null) {
+            searchWorldPresetLabel.setText(getString("label.worldPreset"));
+        }
         if (searchMinXLabel != null) {
             searchMinXLabel.setText(getString("label.minX"));
         }
@@ -1666,6 +1720,11 @@ public class LowYSwampHutForFixedSeed extends JFrame {
         if (searchSortButton != null) {
             searchSortButton.setText(getString("button.sort"));
         }
+        if (worldPresetComboBox != null) {
+            int selectedIndex = worldPresetComboBox.getSelectedIndex();
+            worldPresetComboBox.setModel(new DefaultComboBoxModel<>(getWorldPresetOptions()));
+            worldPresetComboBox.setSelectedIndex(Math.max(0, selectedIndex));
+        }
 
         // 更新进度条和标签
         if (searchProgressBar != null && !isSearchRunning) {
@@ -1695,6 +1754,9 @@ public class LowYSwampHutForFixedSeed extends JFrame {
         }
         if (listSearchVersionLabel != null) {
             listSearchVersionLabel.setText(getString("label.version"));
+        }
+        if (listSearchWorldPresetLabel != null) {
+            listSearchWorldPresetLabel.setText(getString("label.worldPreset"));
         }
         if (listSearchMinXLabel != null) {
             listSearchMinXLabel.setText(getString("label.minX"));
@@ -1736,6 +1798,11 @@ public class LowYSwampHutForFixedSeed extends JFrame {
         }
         if (listSortByDistanceButton != null) {
             listSortByDistanceButton.setText(getString("button.sortByDistance"));
+        }
+        if (listWorldPresetComboBox != null) {
+            int selectedIndex = listWorldPresetComboBox.getSelectedIndex();
+            listWorldPresetComboBox.setModel(new DefaultComboBoxModel<>(getWorldPresetOptions()));
+            listWorldPresetComboBox.setSelectedIndex(Math.max(0, selectedIndex));
         }
         if (listSearchSeedFileButton != null) {
             listSearchSeedFileButton.setText(getString("button.selectFile"));
@@ -1878,6 +1945,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
                 listSearchThreadCountField.setEnabled(true);
                 listMaxHeightComboBox.setEnabled(true);
                 listVersionComboBox.setEnabled(true);
+                listWorldPresetComboBox.setEnabled(true);
                 listMinXField.setEnabled(true);
                 listMaxXField.setEnabled(true);
                 listMinZField.setEnabled(true);
@@ -1965,10 +2033,11 @@ public class LowYSwampHutForFixedSeed extends JFrame {
                     // 获取版本参数
                     String selectedVersion = (String) listVersionComboBox.getSelectedItem();
                     MCVersion mcVersion = getMCVersion(selectedVersion != null ? selectedVersion : "1.21.1");
+                    WorldPresetMode worldPresetMode = getWorldPresetMode((String) listWorldPresetComboBox.getSelectedItem());
 
                     // 如果版本变化，需要重新创建searcher
-                    if (listSearcher == null || !listSearcher.getMCVersion().equals(mcVersion)) {
-                        listSearcher = new SearchCoords(mcVersion);
+                    if (listSearcher == null || !listSearcher.getMCVersion().equals(mcVersion) || listSearcher.getWorldPresetMode() != worldPresetMode) {
+                        listSearcher = new SearchCoords(mcVersion, worldPresetMode);
                     }
 
                     // 批量处理模式下，暂停/恢复功能简化处理
@@ -2163,6 +2232,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
             listSearchThreadCountField.setEnabled(false);
             listMaxHeightComboBox.setEnabled(false);
             listVersionComboBox.setEnabled(false);
+            listWorldPresetComboBox.setEnabled(false);
             listMinXField.setEnabled(false);
             listMaxXField.setEnabled(false);
             listMinZField.setEnabled(false);
@@ -2181,6 +2251,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
             // 获取选择的版本
             String selectedVersion = (String) listVersionComboBox.getSelectedItem();
             MCVersion mcVersion = getMCVersion(selectedVersion != null ? selectedVersion : "1.21.1");
+            WorldPresetMode worldPresetMode = getWorldPresetMode((String) listWorldPresetComboBox.getSelectedItem());
 
             // 在新线程中批量处理所有种子
             final int finalThreadCount = threadCount;
@@ -2261,7 +2332,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
 
                     seedResults.put(seed, new ArrayList<>());
 
-                    listSearcher = new SearchCoords(mcVersion);
+                    listSearcher = new SearchCoords(mcVersion, worldPresetMode);
                     final long currentSeed = seed;
 
                     // 创建结果回调，按种子分组
@@ -2385,6 +2456,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
                     listSearchThreadCountField.setEnabled(true);
                     listMaxHeightComboBox.setEnabled(true);
                     listVersionComboBox.setEnabled(true);
+                    listWorldPresetComboBox.setEnabled(true);
                     listMinXField.setEnabled(true);
                     listMaxXField.setEnabled(true);
                     listMinZField.setEnabled(true);
@@ -2438,6 +2510,7 @@ public class LowYSwampHutForFixedSeed extends JFrame {
         listSearchThreadCountField.setEnabled(true);
         listMaxHeightComboBox.setEnabled(true);
         listVersionComboBox.setEnabled(true);
+        listWorldPresetComboBox.setEnabled(true);
         listMinXField.setEnabled(true);
         listMaxXField.setEnabled(true);
         listMinZField.setEnabled(true);
@@ -2742,4 +2815,3 @@ public class LowYSwampHutForFixedSeed extends JFrame {
         });
     }
 }
-

--- a/src/main/java/project/SearchCoords.java
+++ b/src/main/java/project/SearchCoords.java
@@ -30,6 +30,7 @@ public class SearchCoords {
 
     private final SwampHut swampHut;
     private final MCVersion mcVersion;
+    private final WorldPresetMode worldPresetMode;
     private ExecutorService executor;
     private Thread progressThread;
     private volatile boolean isRunning = false;
@@ -57,8 +58,9 @@ public class SearchCoords {
     public record ProgressInfo(long processed, long total, double percentage, long elapsedMs, long remainingMs) {
     }
 
-    public SearchCoords(MCVersion mcVersion) {
+    public SearchCoords(MCVersion mcVersion, WorldPresetMode worldPresetMode) {
         this.mcVersion = mcVersion;
+        this.worldPresetMode = worldPresetMode;
         this.swampHut = new SwampHut(mcVersion);
     }
 
@@ -229,6 +231,10 @@ public class SearchCoords {
         return mcVersion;
     }
 
+    public WorldPresetMode getWorldPresetMode() {
+        return worldPresetMode;
+    }
+
     class RegionChecker implements Runnable {
         private final long seed;
         private final int startX;
@@ -261,9 +267,9 @@ public class SearchCoords {
             // 根据任务规模决定是否预先初始化线程本地缓存
             // 注意：即使不预热，后续调用处也会按需创建并写入 ThreadLocal
             if (needCache) {
-                NOISE_CACHE.set(new NoiseCache(seed));
+                NOISE_CACHE.set(new NoiseCache(seed, worldPresetMode));
                 CHEESE_CACHE.set(new CheeseNoiseCache(seed));
-                SEED_CHECKER.set(new SeedChecker(seed, TargetState.NO_STRUCTURES, SeedCheckerDimension.OVERWORLD));
+                SEED_CHECKER.set(SeedCheckerFactory.create(seed, TargetState.NO_STRUCTURES, SeedCheckerDimension.OVERWORLD, worldPresetMode));
             }
             // 将maxHeight转换为int，用于Box和check方法
             int maxHeightInt = (int) maxHeight;
@@ -292,7 +298,7 @@ public class SearchCoords {
                     }
                     try {
                         // 计算该点的实际高度
-                        SeedChecker checker = new SeedChecker(seed, TargetState.NO_STRUCTURES, SeedCheckerDimension.OVERWORLD);
+                        SeedChecker checker = SeedCheckerFactory.create(seed, TargetState.NO_STRUCTURES, SeedCheckerDimension.OVERWORLD, worldPresetMode);
                         Box box = new Box(16 * pos.getX() + 3, maxHeightInt, 16 * pos.getZ() + 3,
                                 16 * pos.getX() + 4, 128, 16 * pos.getZ() + 4);
                         if (checker.getBlockCountInBox(Blocks.AIR, box) != expectedAirCount) {
@@ -302,16 +308,21 @@ public class SearchCoords {
                         // 计算整个女巫小屋的实际高度
                         int hutX = 16 * pos.getX();
                         int hutZ = 16 * pos.getZ();
-                        Result result = checkHeight(seed, hutX, hutZ, mcVersion);
+                        Result result = checkHeight(seed, hutX, hutZ, mcVersion, worldPresetMode);
 
                         // 只有当高度 <= maxHeight 时才输出
                         if (!(result.height <= maxHeight)) {
                             checker.clearMemory();
                             continue;
                         }
+                        if (worldPresetMode == WorldPresetMode.LARGE_BIOMES
+                                && !checkHutGeneration(seed, hutX, hutZ, maxHeight, worldPresetMode)) {
+                            checker.clearMemory();
+                            continue;
+                        }
                         // 如果开启了精确检查，检查女巫小屋是否可以生成
                         String resultStr = result.toString();
-                        if (checkGeneration && !checkHutGeneration(seed, hutX, hutZ, maxHeight)) {
+                        if (checkGeneration && !checkHutGeneration(seed, hutX, hutZ, maxHeight, worldPresetMode)) {
                             resultStr += " x";
                         }
                         synchronized (results) {
@@ -348,8 +359,8 @@ public class SearchCoords {
     }
 
     // 检查女巫小屋是否可以生成（检查云杉木板）
-    public static boolean checkHutGeneration(long seed, int hutX, int hutZ, double maxHeight) {
-        SeedChecker checker = new SeedChecker(seed, TargetState.STRUCTURES, SeedCheckerDimension.OVERWORLD);
+    public static boolean checkHutGeneration(long seed, int hutX, int hutZ, double maxHeight, WorldPresetMode worldPresetMode) {
+        SeedChecker checker = SeedCheckerFactory.create(seed, TargetState.STRUCTURES, SeedCheckerDimension.OVERWORLD, worldPresetMode);
         try {
             int startY = (int) (maxHeight + 10);
             for (int y = startY; y >= -54; y--) {
@@ -364,12 +375,12 @@ public class SearchCoords {
     }
 
     // 计算女巫小屋的高度
-    public static Result checkHeight(long seed, int x, int z, MCVersion mcVersion) {
+    public static Result checkHeight(long seed, int x, int z, MCVersion mcVersion, WorldPresetMode worldPresetMode) {
         long structureSeed = seed & 281474976710655L;
         ChunkRand rand = new ChunkRand();
         rand.setCarverSeed(structureSeed, x / 16, z / 16, mcVersion);
         float a = rand.nextFloat();
-        SeedChecker checker = new SeedChecker(seed, TargetState.NO_STRUCTURES, SeedCheckerDimension.OVERWORLD);
+        SeedChecker checker = SeedCheckerFactory.create(seed, TargetState.NO_STRUCTURES, SeedCheckerDimension.OVERWORLD, worldPresetMode);
         int totalHeight = 0;
         if (a < 0.25F || (a >= 0.5F && a < 0.75F)) {
             for (int i = x; i < x + 7; i++) {
@@ -403,10 +414,10 @@ public class SearchCoords {
 
     public boolean check(long seed, int x, int z, int maxHeight) {
         NoiseCache cache;
-        if (currentNeedCache && NOISE_CACHE.get() != null) {
+        if (currentNeedCache && NOISE_CACHE.get() != null && NOISE_CACHE.get().worldPresetMode == worldPresetMode) {
             cache = NOISE_CACHE.get();
         } else {
-            cache = new NoiseCache(seed);
+            cache = new NoiseCache(seed, worldPresetMode);
             if (currentNeedCache) {
                 NOISE_CACHE.set(cache);
             }
@@ -454,11 +465,7 @@ public class SearchCoords {
                 return false;
             }
         }
-        LazyDoublePerlinNoiseSampler continentalnessNoise = LazyDoublePerlinNoiseSampler.createNoiseSampler(
-                new Xoroshiro128PlusPlusRandom(seed).createRandomDeriver(),
-                NoiseParameterKey.CONTINENTALNESS
-        );
-        if (continentalnessNoise.sample((double) x / 4, 0, (double) z / 4) < -0.11) {
+        if (cache.continentalness.sample((double) x / 4, 0, (double) z / 4) < -0.11) {
             return false;
         }
         LazyDoublePerlinNoiseSampler aquiferNoise = LazyDoublePerlinNoiseSampler.createNoiseSampler(
@@ -474,6 +481,7 @@ public class SearchCoords {
     }
 
     private static class NoiseCache {
+        final WorldPresetMode worldPresetMode;
         final LazyDoublePerlinNoiseSampler caveEntrance;
         final LazyDoublePerlinNoiseSampler spaghettiRarity;
         final LazyDoublePerlinNoiseSampler spaghettiThickness;
@@ -483,9 +491,11 @@ public class SearchCoords {
         final LazyDoublePerlinNoiseSampler spaghettiRoughness;
         final LazyDoublePerlinNoiseSampler erosion;
         final LazyDoublePerlinNoiseSampler temperature;
+        final LazyDoublePerlinNoiseSampler continentalness;
         final LazyDoublePerlinNoiseSampler ridge;
 
-        NoiseCache(long worldSeed) {
+        NoiseCache(long worldSeed, WorldPresetMode worldPresetMode) {
+            this.worldPresetMode = worldPresetMode;
             Xoroshiro128PlusPlusRandom random = new Xoroshiro128PlusPlusRandom(worldSeed);
             var deriver = random.createRandomDeriver();
             caveEntrance = LazyDoublePerlinNoiseSampler.createNoiseSampler(deriver, NoiseParameterKey.CAVE_ENTRANCE);
@@ -495,8 +505,12 @@ public class SearchCoords {
             spaghetti3D2 = LazyDoublePerlinNoiseSampler.createNoiseSampler(deriver, NoiseParameterKey.SPAGHETTI_3D_2);
             spaghettiRoughnessModulator = LazyDoublePerlinNoiseSampler.createNoiseSampler(deriver, NoiseParameterKey.SPAGHETTI_ROUGHNESS_MODULATOR);
             spaghettiRoughness = LazyDoublePerlinNoiseSampler.createNoiseSampler(deriver, NoiseParameterKey.SPAGHETTI_ROUGHNESS);
-            erosion = LazyDoublePerlinNoiseSampler.createNoiseSampler(deriver, NoiseParameterKey.EROSION);
-            temperature = LazyDoublePerlinNoiseSampler.createNoiseSampler(deriver, NoiseParameterKey.TEMPERATURE);
+            NoiseParameterKey erosionKey = worldPresetMode == WorldPresetMode.LARGE_BIOMES ? NoiseParameterKey.EROSION_LARGE : NoiseParameterKey.EROSION;
+            NoiseParameterKey temperatureKey = worldPresetMode == WorldPresetMode.LARGE_BIOMES ? NoiseParameterKey.TEMPERATURE_LARGE : NoiseParameterKey.TEMPERATURE;
+            NoiseParameterKey continentalnessKey = worldPresetMode == WorldPresetMode.LARGE_BIOMES ? NoiseParameterKey.CONTINENTALNESS_LARGE : NoiseParameterKey.CONTINENTALNESS;
+            erosion = LazyDoublePerlinNoiseSampler.createNoiseSampler(deriver, erosionKey);
+            temperature = LazyDoublePerlinNoiseSampler.createNoiseSampler(deriver, temperatureKey);
+            continentalness = LazyDoublePerlinNoiseSampler.createNoiseSampler(deriver, continentalnessKey);
             ridge = LazyDoublePerlinNoiseSampler.createNoiseSampler(deriver, NoiseParameterKey.RIDGE);
         }
     }
@@ -518,7 +532,7 @@ public class SearchCoords {
         if (needCache && NOISE_CACHE.get() != null) {
             cache = NOISE_CACHE.get();
         } else {
-            cache = new NoiseCache(worldSeed);
+            cache = new NoiseCache(worldSeed, WorldPresetMode.NORMAL);
             if (needCache) {
                 NOISE_CACHE.set(cache);
             }
@@ -558,7 +572,7 @@ public class SearchCoords {
         if (needCache && NOISE_CACHE.get() != null) {
             cache = NOISE_CACHE.get();
         } else {
-            cache = new NoiseCache(worldSeed);
+            cache = new NoiseCache(worldSeed, WorldPresetMode.NORMAL);
             if (needCache) {
                 NOISE_CACHE.set(cache);
             }
@@ -576,4 +590,3 @@ public class SearchCoords {
         return p + q;
     }
 }
-

--- a/src/main/java/project/SearchCoords.java
+++ b/src/main/java/project/SearchCoords.java
@@ -305,10 +305,13 @@ public class SearchCoords {
                             checker.clearMemory();
                             continue;
                         }
-                        // 计算整个女巫小屋的实际高度
+                        // 优先使用真实生成的小屋最低Y（地板Y-1），未生成时再回退到地形估算高度
                         int hutX = 16 * pos.getX();
                         int hutZ = 16 * pos.getZ();
-                        Result result = checkHeight(seed, hutX, hutZ, mcVersion, worldPresetMode);
+                        Integer generatedFloorY = findGeneratedHutFloorY(seed, hutX, hutZ, worldPresetMode);
+                        Result result = generatedFloorY != null
+                                ? new Result(hutX, hutZ, generatedFloorY - 1)
+                                : checkHeight(seed, hutX, hutZ, mcVersion, worldPresetMode);
 
                         // 只有当高度 <= maxHeight 时才输出
                         if (!(result.height <= maxHeight)) {
@@ -316,13 +319,13 @@ public class SearchCoords {
                             continue;
                         }
                         if (worldPresetMode == WorldPresetMode.LARGE_BIOMES
-                                && !checkHutGeneration(seed, hutX, hutZ, maxHeight, worldPresetMode)) {
+                                && generatedFloorY == null) {
                             checker.clearMemory();
                             continue;
                         }
                         // 如果开启了精确检查，检查女巫小屋是否可以生成
                         String resultStr = result.toString();
-                        if (checkGeneration && !checkHutGeneration(seed, hutX, hutZ, maxHeight, worldPresetMode)) {
+                        if (checkGeneration && generatedFloorY == null) {
                             resultStr += " x";
                         }
                         synchronized (results) {
@@ -360,21 +363,24 @@ public class SearchCoords {
 
     // 检查女巫小屋是否可以生成（检查云杉木板）
     public static boolean checkHutGeneration(long seed, int hutX, int hutZ, double maxHeight, WorldPresetMode worldPresetMode) {
+        return findGeneratedHutFloorY(seed, hutX, hutZ, worldPresetMode) != null;
+    }
+
+    public static Integer findGeneratedHutFloorY(long seed, int hutX, int hutZ, WorldPresetMode worldPresetMode) {
         SeedChecker checker = SeedCheckerFactory.create(seed, TargetState.STRUCTURES, SeedCheckerDimension.OVERWORLD, worldPresetMode);
         try {
-            int startY = (int) (maxHeight + 10);
-            for (int y = startY; y >= -54; y--) {
+            for (int y = -64; y <= 200; y++) {
                 if (checker.getBlock(hutX + 2, y, hutZ + 2) == Blocks.SPRUCE_PLANKS) {
-                    return true;
+                    return y;
                 }
             }
-            return false;
+            return null;
         } finally {
             checker.clearMemory();
         }
     }
 
-    // 计算女巫小屋的高度
+    // 估算女巫小屋所在区域的地形高度，用作未生成结构时的回退值
     public static Result checkHeight(long seed, int x, int z, MCVersion mcVersion, WorldPresetMode worldPresetMode) {
         long structureSeed = seed & 281474976710655L;
         ChunkRand rand = new ChunkRand();

--- a/src/main/java/project/SeedCheckerFactory.java
+++ b/src/main/java/project/SeedCheckerFactory.java
@@ -1,0 +1,37 @@
+package project;
+
+import nl.jellejurre.seedchecker.SeedChecker;
+import nl.jellejurre.seedchecker.SeedCheckerDimension;
+import nl.jellejurre.seedchecker.TargetState;
+import nl.jellejurre.seedchecker.serverMocks.FakeSaveProperties;
+
+import java.util.function.Supplier;
+
+public final class SeedCheckerFactory {
+    private SeedCheckerFactory() {
+    }
+
+    public static SeedChecker create(long seed, TargetState state, SeedCheckerDimension dimension, WorldPresetMode worldPresetMode) {
+        return withPreset(worldPresetMode, () -> new SeedChecker(seed, state, dimension));
+    }
+
+    public static SeedChecker create(long seed, int targetLevel, SeedCheckerDimension dimension, WorldPresetMode worldPresetMode) {
+        return withPreset(worldPresetMode, () -> new SeedChecker(seed, targetLevel, dimension));
+    }
+
+    public static void runWithPreset(WorldPresetMode worldPresetMode, Runnable runnable) {
+        withPreset(worldPresetMode, () -> {
+            runnable.run();
+            return null;
+        });
+    }
+
+    private static <T> T withPreset(WorldPresetMode worldPresetMode, Supplier<T> supplier) {
+        FakeSaveProperties.setWorldPresetMode(worldPresetMode);
+        try {
+            return supplier.get();
+        } finally {
+            FakeSaveProperties.clearWorldPresetMode();
+        }
+    }
+}

--- a/src/main/java/project/SeedCheckerInitializer.java
+++ b/src/main/java/project/SeedCheckerInitializer.java
@@ -16,6 +16,10 @@ public class SeedCheckerInitializer {
      * 这必须在任何多线程使用 SeedChecker 之前调用
      */
     public static void initialize() {
+        initialize(WorldPresetMode.NORMAL);
+    }
+
+    public static void initialize(WorldPresetMode worldPresetMode) {
         if (initialized) {
             return;
         }
@@ -39,8 +43,10 @@ public class SeedCheckerInitializer {
                 // 使用同步块确保只有一个线程初始化
                 // 注意：SharedConstants 应该已经在 Launcher 中初始化了
                 synchronized (SeedCheckerInitializer.class) {
-                    SeedChecker preInit = new SeedChecker(0L, TargetState.NO_STRUCTURES, SeedCheckerDimension.OVERWORLD);
-                    preInit.clearMemory();
+                    SeedCheckerFactory.runWithPreset(worldPresetMode, () -> {
+                        SeedChecker preInit = new SeedChecker(0L, TargetState.NO_STRUCTURES, SeedCheckerDimension.OVERWORLD);
+                        preInit.clearMemory();
+                    });
                 }
                 initialized = true;
             } catch (ExceptionInInitializerError e) {
@@ -68,4 +74,3 @@ public class SeedCheckerInitializer {
         }
     }
 }
-

--- a/src/main/java/project/WorldPresetMode.java
+++ b/src/main/java/project/WorldPresetMode.java
@@ -1,0 +1,6 @@
+package project;
+
+public enum WorldPresetMode {
+    NORMAL,
+    LARGE_BIOMES
+}

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -12,6 +12,7 @@ label.seed=Seed:
 label.threadCount=Thread Count:
 label.heightFilter=Filter Witch Hut Height (The Higher, the slower):
 label.version=Version:
+label.worldPreset=World Preset:
 label.minX=MinX(x512):
 label.maxX=MaxX(x512):
 label.minZ=MinZ(x512):
@@ -113,4 +114,5 @@ dialog.textFiles=Text Files (*.txt)
 # Default file names
 file.searchOutput=search_output.txt
 file.seedList=seed_list.txt
-
+worldPreset.normal=Normal
+worldPreset.largeBiomes=Large Biomes

--- a/src/main/resources/messages_zh_CN.properties
+++ b/src/main/resources/messages_zh_CN.properties
@@ -12,6 +12,7 @@ label.seed=种子:
 label.threadCount=线程数:
 label.heightFilter=筛选女巫小屋高度(高度越高搜索越慢):
 label.version=版本:
+label.worldPreset=世界类型:
 label.minX=MinX(x512):
 label.maxX=MaxX(x512):
 label.minZ=MinZ(x512):
@@ -113,4 +114,5 @@ dialog.textFiles=文本文件 (*.txt)
 # 默认文件名
 file.searchOutput=search_output.txt
 file.seedList=seed_list.txt
-
+worldPreset.normal=普通世界
+worldPreset.largeBiomes=巨型生物群系

--- a/src/test/java/project/LargeBiomesRegressionTest.java
+++ b/src/test/java/project/LargeBiomesRegressionTest.java
@@ -1,0 +1,63 @@
+package project;
+
+import net.minecraft.block.Block;
+import nl.jellejurre.seedchecker.SeedChecker;
+import nl.jellejurre.seedchecker.SeedCheckerDimension;
+import nl.jellejurre.seedchecker.TargetState;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LargeBiomesRegressionTest {
+
+    @Test
+    @Timeout(30)
+    void largeBiomesPresetChangesTerrainForFixedSeeds() {
+        long[] seeds = {0L, 1L, 12345L, -987654321L};
+        boolean foundDifference = false;
+
+        for (long seed : seeds) {
+            SeedChecker normal = SeedCheckerFactory.create(seed, TargetState.NO_STRUCTURES, SeedCheckerDimension.OVERWORLD, WorldPresetMode.NORMAL);
+            SeedChecker large = SeedCheckerFactory.create(seed, TargetState.NO_STRUCTURES, SeedCheckerDimension.OVERWORLD, WorldPresetMode.LARGE_BIOMES);
+            try {
+                if (terrainDiffers(normal, large)) {
+                    foundDifference = true;
+                    break;
+                }
+            } finally {
+                normal.clearMemory();
+                large.clearMemory();
+            }
+        }
+
+        assertTrue(foundDifference, "Expected Large Biomes terrain to differ from Normal terrain in the fixed regression search space");
+    }
+
+    private static boolean terrainDiffers(SeedChecker normal, SeedChecker large) {
+        for (int x = -512; x <= 512; x += 32) {
+            for (int z = -512; z <= 512; z += 32) {
+                int normalY = findTopSolidY(normal, x, z);
+                int largeY = findTopSolidY(large, x, z);
+                if (normalY != largeY) {
+                    return true;
+                }
+                Block normalBlock = normal.getBlock(x, normalY, z);
+                Block largeBlock = large.getBlock(x, largeY, z);
+                if (normalBlock != largeBlock) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static int findTopSolidY(SeedChecker checker, int x, int z) {
+        for (int y = 128; y >= -55; y--) {
+            if (!checker.getBlockState(x, y, z).isAir()) {
+                return y;
+            }
+        }
+        return -55;
+    }
+}


### PR DESCRIPTION
### What
  This PR adds support for the `Large Biomes` world preset and improves result Y accuracy
  by preferring the generated swamp hut floor Y when available.

  Specifically:
  - Add a `World Preset` option to both single-seed search and seed-list search
  - Pass the selected world preset through the search and validation pipeline
  - Use `EROSION_LARGE`, `TEMPERATURE_LARGE`, and `CONTINENTALNESS_LARGE`
    when searching in `Large Biomes`
  - Create `SeedChecker` instances with the corresponding world preset
  - Prefer the generated hut floor Y and return `floorY - 1` as the final result height
  - Fall back to terrain-based estimation only when the hut is not actually generated
  - Add a regression test to ensure `Large Biomes` terrain differs from `Normal`

  ---

  ### 内容说明
  本次提交主要增加了 `巨型生物群系（Large Biomes）` 世界预设支持，
  并进一步提高了结果 Y 值的准确性，在可用时优先使用女巫小屋实际生成后的地板高度。

  具体包括：
  - 在单种子搜索和种子列表搜索中增加 `世界预设 / World Preset` 选项
  - 将所选世界预设传递到搜索与校验逻辑中
  - 在 `Large Biomes` 模式下使用对应的大型生物群系噪声参数
  - 使用对应世界预设创建 `SeedChecker`，使地形与结构校验和实际世界生成一致
  - 当女巫小屋实际生成时，优先使用真实生成的小屋地板高度，并返回 `floorY - 1`
  - 仅在结构未实际生成时，才回退到原有的地形估算逻辑
  - 增加回归测试，验证同一种子下 `Normal` 与 `Large Biomes` 的地形结果确实不同

  ---

  ### Why
  Using only biome/noise-side adjustments is not enough for `Large Biomes`.
  If the world preset is not also propagated into `SeedChecker`, the search result may
  diverge from actual world generation.

  In addition, result Y could still be inaccurate in some cases if it relies on estimated terrain height.
  Using the generated hut floor gives a more stable and structure-specific result.

  ---

  ### 优化动机
  如果只调整群系参数和噪声筛选，而不将世界预设同步传入 `SeedChecker`，
  那么 `Large Biomes` 下的搜索结果可能会与实际世界生成不一致。

  另外，若结果 Y 值仍依赖地形估算，在部分情况下会出现偏差。
  因此这里改为优先使用实际生成后的小屋地板高度，以得到更稳定、更准确的结构高度结果。

  ---

  ### How
  - Introduce a `WorldPresetMode` abstraction for `Normal` and `Large Biomes`
  - Thread the selected preset through UI, search logic, and `SeedChecker` creation
  - Use preset-specific noise keys for biome-related filtering
  - Wrap `SeedChecker` creation so the correct generator preset is used
  - Detect generated hut floor blocks and use that value as the preferred result Y

  ---

  ### 实现方式
  - 新增 `WorldPresetMode`，用于区分 `普通世界` 和 `巨型生物群系`
  - 将用户选择的世界预设从界面一路传递到搜索逻辑和 `SeedChecker` 创建流程
  - 在群系筛选中为 `Large Biomes` 使用对应的大型噪声参数
  - 对 `SeedChecker` 的创建流程进行封装，使其使用正确的世界生成预设
  - 通过检测实际生成的小屋地板方块，优先使用真实结构高度作为结果 Y 值

  ---

  ### Impact
  - Adds `Large Biomes` support for supported versions
  - Improves height accuracy for generated huts
  - Main impact is correctness and feature support

  ---

  ### 影响范围
  - 为当前支持的版本增加 `Large Biomes` 搜索支持
  - 提高实际生成女巫小屋的高度结果精度
  - 主要影响为功能补全和结果正确性提升

  ---

  ### Test
  - `./gradlew test`
  - Manually verified several seeds in `Large Biomes`
  - Fixed the previously observed Y mismatch by preferring generated hut floor Y

  ---

  ### 测试情况
  - 运行 `./gradlew test`
  - 对若干 `Large Biomes` 种子进行了手动验证
  - 针对之前出现过的 Y 值偏差问题，改为优先使用实际生成的小屋地板高度后进行了修正
